### PR TITLE
Fix: Query string parameters not apended to the final query URL

### DIFF
--- a/src/Envato/Endpoint.php
+++ b/src/Envato/Endpoint.php
@@ -79,7 +79,10 @@ namespace Herbert\Envato {
             $client = $this->createHttpClient();
 
             // Build the HTTP query
-            $query = http_build_query($variables);
+	        if(!empty($variables)) {
+		        $query = http_build_query($variables);
+		        $uri  .= '?' . $query;
+	        }
 
             // Send the request
             $response = $client->request('GET', $uri, [


### PR DESCRIPTION
I tried to list the codecanyon.net items but the query didn't worked, so i found out that the parameters aren't appended to the query URL. Feel free to merge the fix.