### PR TITLE
Fix key overlap for sales history endpoint.

### DIFF
--- a/src/Envato/Schema.php
+++ b/src/Envato/Schema.php
@@ -48,7 +48,7 @@ namespace Herbert\Envato {
                     'details' => '/v1/market/private/user/account.json',
                     'username' => '/v1/market/private/user/username.json',
                     'email' => '/v1/market/private/user/email.json',
-                    'sales' => '/v1/market/private/user/earnings-and-sales-by-month.json',
+                    'earnings' => '/v1/market/private/user/earnings-and-sales-by-month.json',
                     'statement' => '/v3/market/user/statement',
                 ],
 


### PR DESCRIPTION
The `sales` was duplicated below, preventing being able to fetch sales history from Envato's API. This small change fixes that.