### PR TITLE
Update guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "guzzlehttp/guzzle": "^6.5.5"
+        "guzzlehttp/guzzle": "^7.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"


### PR DESCRIPTION
To remove guzzle dependency with latest version:

`baileyherbert/envato 3.0.0 requires guzzlehttp/guzzle ^6.5.5 -> found guzzlehttp/guzzle[6.5.5, ..., 6.5.x-dev]`